### PR TITLE
Fix audio interruptions causing playhead to reset

### DIFF
--- a/NYPLAudiobookToolkit/Player/FindawayPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/FindawayPlayer.swift
@@ -443,6 +443,11 @@ extension FindawayPlayer: FindawayPlaybackNotificationHandlerDelegate {
                 DispatchQueue.main.async { [weak self] () -> Void in
                     self?.notifyDelegatesOfPauseFor(chapter: currentChapter)
                 }
+                if self.resumePlaybackLocation == nil {
+                    self.queue.sync {
+                        self.resumePlaybackLocation = currentChapter
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
When audio engine pauses itself, we need to save the playhead