### PR TITLE
Add activity indicator when player is waiting for playback to begin

### DIFF
--- a/NYPLAudiobookToolkitDemoApp/AudiobookController.swift
+++ b/NYPLAudiobookToolkitDemoApp/AudiobookController.swift
@@ -9,10 +9,6 @@
 import UIKit
 import NYPLAudiobookToolkit
 
-protocol PlayheadStore {
-    func savePlayhead()
-}
-
 class AudiobookController {
     var manager: AudiobookManager?
     func configurePlayhead() {
@@ -70,9 +66,7 @@ class AudiobookController {
         let fullURL = documentsURL.appendingPathComponent("\(audiobookID).playhead")
         return fullURL?.path
     }
-}
 
-extension AudiobookController: PlayheadStore {
     public func savePlayhead() {
         guard let chapter = self.manager?.audiobook.player.currentChapterLocation else {
             return


### PR DESCRIPTION
The player takes forever to do things sometime, it is nice to have a spinner that does not lock the screen when we are waiting for stuff to actually happen