### PR TITLE
Update swift classes to ensure members are visible in ObjC

### DIFF
--- a/NYPLAudiobookToolkit.xcodeproj/project.pbxproj
+++ b/NYPLAudiobookToolkit.xcodeproj/project.pbxproj
@@ -500,7 +500,7 @@
 				TargetAttributes = {
 					7B54418B200EA7C20047B6C6 = {
 						CreatedOnToolsVersion = 9.2;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 0930;
 						ProvisioningStyle = Automatic;
 					};
 					7B544194200EA7C20047B6C6 = {

--- a/NYPLAudiobookToolkit/Core/Audiobook.swift
+++ b/NYPLAudiobookToolkit/Core/Audiobook.swift
@@ -24,7 +24,7 @@ import UIKit
 /// Host app should instantiate a audiobook object with JSON.
 /// This audiobook should then be able to construct utility classes
 /// using data in the spine of that JSON.
-@objc public final class AudiobookFactory: NSObject {
+@objcMembers public final class AudiobookFactory: NSObject {
     public static func audiobook(_ JSON: Any?) -> Audiobook? {
         guard let JSON = JSON as? [String: Any] else { return nil }
         let metadata = JSON["metadata"] as? [String: Any]

--- a/NYPLAudiobookToolkit/Core/AudiobookLifecycleManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookLifecycleManager.swift
@@ -20,7 +20,7 @@ import AVFoundation
 /// Hooks into life cycle events for AppDelegate.swift. Listens to notifcations from
 /// AudioEngine to ensure other objects know when it is safe to perform operations on
 /// their SDK.
-public class AudiobookLifecycleManager: NSObject {
+@objcMembers public class AudiobookLifecycleManager: NSObject {
     /**
      The shared instance of the lifecycle manager intended for usage throughout the framework.
      */

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -76,7 +76,7 @@ import Foundation
 }
 
 /// This class represents a location in a book.
-@objc public final class ChapterLocation: NSObject, Codable {
+@objcMembers public final class ChapterLocation: NSObject, Codable {
     public let title: String?
     public let number: UInt
     public let part: UInt


### PR DESCRIPTION
In Swift 4 the default was flipped, it used to be all class members
which do not take advantage of swift specific features were visible
from ObjC. Now you need to specificly state which members should
be objc visible.

protocols still work the old way where @objc makes all its members
visible