### PR TITLE
Resolves bug where `traitCollectionDidChange` doesn't fire

### DIFF
--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -234,6 +234,8 @@ let SkipTimeInterval: Double = 15
             timeLeftInBook: self.timeLeftAfter(chapter: chapter),
             middleText: self.middleTextFor(chapter: chapter)
         )
+
+        enableConstraints() // iOS < 13 used to guarantee `traitCollectionDidChange` was called, but not anymore
     }
   
     override public func viewDidLayoutSubviews() {
@@ -264,7 +266,12 @@ let SkipTimeInterval: Double = 15
 
     override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        enableConstraints()
+    }
 
+    //MARK:-
+
+    func enableConstraints() {
         if traitCollection.horizontalSizeClass == .regular {
             if compactWidthConstraints.count > 0 && compactWidthConstraints[0].isActive {
                 NSLayoutConstraint.deactivate(compactWidthConstraints)
@@ -277,8 +284,6 @@ let SkipTimeInterval: Double = 15
             NSLayoutConstraint.activate(compactWidthConstraints)
         }
     }
-
-    //MARK:-
     
     func timeLeftAfter(chapter: ChapterLocation) -> TimeInterval {
         let spine = self.audiobookManager.audiobook.spine

--- a/NYPLAudiobookToolkit/UI/ChapterInfoStack.swift
+++ b/NYPLAudiobookToolkit/UI/ChapterInfoStack.swift
@@ -62,9 +62,15 @@ class ChapterInfoStack: UIView {
         self.bottomLabel.textColor = UIColor.darkGray
         self.bottomLabel.setContentHuggingPriority(.defaultLow, for: .vertical)
         self.bottomLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+      
+        enableConstraints() // iOS < 13 used to guarantee `traitCollectionDidChange` was called, but not anymore
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        enableConstraints()
+    }
+
+    func enableConstraints() {
         if traitCollection.verticalSizeClass == .regular && traitCollection.horizontalSizeClass == .regular {
             self.topLabel.font = UIFont.boldSystemFont(ofSize: 22)
             self.bottomLabel.font = UIFont.boldSystemFont(ofSize: 22)

--- a/NYPLAudiobookToolkit/UI/PlaybackControlView.swift
+++ b/NYPLAudiobookToolkit/UI/PlaybackControlView.swift
@@ -152,8 +152,10 @@ final class PlaybackControlView: UIView {
             self.skipBackView.autoPinEdge(.right, to: .left, of: self.playButton, withOffset: -self.horizontalPadding * 2)
             self.skipForwardView.autoPinEdge(.left, to: .right, of: self.playButton, withOffset: self.horizontalPadding * 2)
         }
+      
+        enableConstraints() // iOS < 13 used to guarantee `traitCollectionDidChange` was called, but not anymore
     }
-    
+
     @objc public func playButtonWasTapped(_ sender: Any) {
         self.togglePlayPauseButtonUIState()
         if self.playButton.image == self.pauseImage {
@@ -172,6 +174,10 @@ final class PlaybackControlView: UIView {
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        enableConstraints()
+    }
+
+    func enableConstraints() {
         if traitCollection.verticalSizeClass == .regular && traitCollection.horizontalSizeClass == .regular {
             if compactConstraints.count > 0 && compactConstraints[0].isActive {
                 NSLayoutConstraint.deactivate(compactConstraints)


### PR DESCRIPTION
iOS13 changed their behaviour such that it's not guaranteed to fire when added to the view hierarchy. This means that neither compact nor regular constraints are set initially.