### PR TITLE
SIMPLY-3265 SimplyE rejects audiobook format based on an irrelevant discrepancy in media type between CM and Feedbooks

### DIFF
--- a/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
@@ -47,8 +47,8 @@ final class OpenAccessSpineElement: SpineElement {
                 ATLog(.error, "OpenAccessSpineElement failed to init from JSON: \n\(JSON ?? "nil")")
                 return nil
         }
-        let defaultTitleFormat = NSLocalizedString("Chapter %d", bundle: Bundle.audiobookToolkit()!, value: "Chapter %d", comment: "Default chapter title")
-        self.title = payload["title"] as? String ?? String(format: defaultTitleFormat, index + 1)
+        let defaultTitleFormat = NSLocalizedString("Chapter %@", bundle: Bundle.audiobookToolkit()!, value: "Chapter %@", comment: "Default chapter title")
+        self.title = payload["title"] as? String ?? String(format: defaultTitleFormat, "\(index + 1)")
         self.url = url
         self.urlString = urlString
         self.duration = duration

--- a/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
@@ -41,14 +41,13 @@ final class OpenAccessSpineElement: SpineElement {
         self.audiobookID = audiobookID
 
         guard let payload = JSON as? [String: Any],
-            let title = payload["title"] as? String,
             let urlString = payload["href"] as? String,
             let url = URL(string: urlString),
             let duration = payload["duration"] as? TimeInterval else {
                 ATLog(.error, "OpenAccessSpineElement failed to init from JSON: \n\(JSON ?? "nil")")
                 return nil
         }
-        self.title = title
+        self.title = payload["title"] as? String ?? "Chapter \(index + 1)"
         self.url = url
         self.urlString = urlString
         self.duration = duration

--- a/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
@@ -47,7 +47,8 @@ final class OpenAccessSpineElement: SpineElement {
                 ATLog(.error, "OpenAccessSpineElement failed to init from JSON: \n\(JSON ?? "nil")")
                 return nil
         }
-        self.title = payload["title"] as? String ?? "Chapter \(index + 1)"
+        let defaultTitleFormat = NSLocalizedString("Chapter %d", bundle: Bundle.audiobookToolkit()!, value: "Chapter %d", comment: "Default chapter title")
+        self.title = payload["title"] as? String ?? String(format: defaultTitleFormat, index + 1)
         self.url = url
         self.urlString = urlString
         self.duration = duration


### PR DESCRIPTION
This PR fixes the issue with audiobooks was found in St. Mary's County Library. The reason was DPLA audiobooks with spine elements without title.

**Ticket:**
https://jira.nypl.org/browse/SIMPLY-3265

**How to test:**
try to open a DPLA audiobook in St. Mary's County Library, for example, "The Book of Koli" or "The Martyrdom of Collins Catch the Bear". Tap the button with three lines in the top right corner to open chapters, chapters should read "Chapter 1", "Chapter 2", etc.