### PR TITLE
SIMPLY-3278 SimplyE change the word "Part" in the audiobook player to "Chapter"

### DIFF
--- a/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
@@ -47,8 +47,8 @@ final class OpenAccessSpineElement: SpineElement {
                 ATLog(.error, "OpenAccessSpineElement failed to init from JSON: \n\(JSON ?? "nil")")
                 return nil
         }
-        let defaultTitleFormat = NSLocalizedString("Chapter %d", bundle: Bundle.audiobookToolkit()!, value: "Chapter %d", comment: "Default chapter title")
-        self.title = payload["title"] as? String ?? String(format: defaultTitleFormat, index + 1)
+        let defaultTitleFormat = NSLocalizedString("Chapter %@", bundle: Bundle.audiobookToolkit()!, value: "Chapter %@", comment: "Default chapter title")
+        self.title = payload["title"] as? String ?? String(format: defaultTitleFormat, "\(index + 1)")
         self.url = url
         self.urlString = urlString
         self.duration = duration

--- a/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
@@ -41,14 +41,13 @@ final class OpenAccessSpineElement: SpineElement {
         self.audiobookID = audiobookID
 
         guard let payload = JSON as? [String: Any],
-            let title = payload["title"] as? String,
             let urlString = payload["href"] as? String,
             let url = URL(string: urlString),
             let duration = payload["duration"] as? TimeInterval else {
                 ATLog(.error, "OpenAccessSpineElement failed to init from JSON: \n\(JSON ?? "nil")")
                 return nil
         }
-        self.title = title
+        self.title = payload["title"] as? String ?? "Chapter \(index + 1)"
         self.url = url
         self.urlString = urlString
         self.duration = duration

--- a/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OpenAccessSpineElement.swift
@@ -47,7 +47,8 @@ final class OpenAccessSpineElement: SpineElement {
                 ATLog(.error, "OpenAccessSpineElement failed to init from JSON: \n\(JSON ?? "nil")")
                 return nil
         }
-        self.title = payload["title"] as? String ?? "Chapter \(index + 1)"
+        let defaultTitleFormat = NSLocalizedString("Chapter %d", bundle: Bundle.audiobookToolkit()!, value: "Chapter %d", comment: "Default chapter title")
+        self.title = payload["title"] as? String ?? String(format: defaultTitleFormat, index + 1)
         self.url = url
         self.urlString = urlString
         self.duration = duration

--- a/NYPLAudiobookToolkit/Core/OverdriveSpineElement.swift
+++ b/NYPLAudiobookToolkit/Core/OverdriveSpineElement.swift
@@ -29,9 +29,11 @@ final class OverdriveSpineElement: SpineElement {
     init?(JSON: Any?, index: UInt, audiobookID: String) {
         self.key = "\(audiobookID)-\(index)"
         self.chapterNumber = index
-        self.title = "Part \(index + 1)"
         self.audiobookID = audiobookID
-        
+
+        let defaultTitleFormat = NSLocalizedString("Chapter %@", bundle: Bundle.audiobookToolkit()!, value: "Chapter %@", comment: "Default chapter title")
+        self.title = String(format: defaultTitleFormat, "\(index + 1)")
+
         guard let payload = JSON as? [String: Any],
         let urlString = payload["href"] as? String,
         let url = URL(string: urlString),

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -502,9 +502,11 @@ let SkipTimeInterval: Double = 15
     }
 
     func middleTextFor(chapter: ChapterLocation) -> String {
-        let middleTextFormat = NSLocalizedString("Part %@ of %d", bundle: Bundle.audiobookToolkit()!, value: "Part %@ of %d", comment: "Current chapter and the amount of chapters left in the book")
+        let defaultTitleFormat = NSLocalizedString("Chapter %@", bundle: Bundle.audiobookToolkit()!, value: "Chapter %@", comment: "Default chapter title")
+        let middleTextFormat = NSLocalizedString("%@ (file %@ of %d)", bundle: Bundle.audiobookToolkit()!, value: "%@ (file %@ of %d)", comment: "Current chapter and the amount of chapters left in the book")
         let indexString = oneBasedSpineIndex() ?? "--"
-        return String(format: middleTextFormat, indexString, self.audiobookManager.audiobook.spine.count)
+        let title = chapter.title ?? String(format: defaultTitleFormat, indexString)
+        return String(format: middleTextFormat, title, indexString, self.audiobookManager.audiobook.spine.count)
     }
 
     func playbackSpeedTextFor(speedText: String) -> String {


### PR DESCRIPTION
We change the word "Part" in audiobooks (on the cover and in TOC) to "Chapter" to match SimplyE on Android, and add "file" in front of the spine element number "of" number of spine elements:
[_TOC name_|"Chapter x"] ([file x of y])

**Ticket:**
https://jira.nypl.org/browse/SIMPLY-3278

**How to test:**
Try to open an audiobook and check the cover. 

![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-11-12 at 22 46 07](https://user-images.githubusercontent.com/941531/98976274-fb554d80-2538-11eb-876e-f4db1b7576ff.png)
