### PR TITLE
iOS-349 Use NYPLRepeatingTimer instead of DispatchSourceTimer

### DIFF
--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 import MediaPlayer
 import AVFoundation
+import NYPLUtilities
 
 /// If the AudiobookManager runs into an error that may
 /// be resolved by fetching a new audiobook manifest from
@@ -85,7 +86,7 @@ var sharedLogHandler: LogHandler?
         return SleepTimer(player: self.audiobook.player)
     }()
 
-    private var progressSavingTimer: DispatchSourceTimer?
+    private var progressSavingTimer: NYPLRepeatingTimer?
     private(set) public var timer: Timer?
     private let mediaControlHandler: MediaControlHandler
     public init (metadata: AudiobookMetadata, audiobook: Audiobook, networkService: AudiobookNetworkService) {
@@ -181,29 +182,11 @@ var sharedLogHandler: LogHandler?
   
     // MARK: - Helper for ProgressSavingTimer
   
-    public func setProgressSavingTimer(_ timer: DispatchSourceTimer) {
-        // Cancel previous timer if existed
-        if !progressSavingTimerIsNil() {
-            cancelProgressSavingTimer()
-        }
-        
+    public func setProgressSavingTimer(_ timer: NYPLRepeatingTimer) {
         self.progressSavingTimer = timer
-      
-        // Make sure timer is in the right state,
-        // calling resume or suspend twice in a row will cause a crash
-        // ref: https://developer.apple.com/forums/thread/15902?answerId=669654022#669654022
-        if !self.audiobook.player.isPlaying {
-            self.progressSavingTimer?.suspend()
-        }
     }
   
     public func cancelProgressSavingTimer() {
-        // Make sure timer is in the right state,
-        // releasing a suspended timer will cause a crash
-        // ref: https://developer.apple.com/forums/thread/15902?answerId=669654022#669654022
-        if !self.audiobook.player.isPlaying {
-            self.progressSavingTimer?.resume()
-        }
         self.progressSavingTimer = nil
     }
   

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/NYPL-Simplified/iOS-Utilities.git",
         "state": {
           "branch": "main",
-          "revision": "dda470221a5e6eca49e1acef8bd2c08bebbeebe1",
+          "revision": "0f4dda618061dbf2a360aaed39a140c43d797248",
           "version": null
         }
       },


### PR DESCRIPTION
With NYPLRepeatingTimer, we don't need to worry about crash caused by calling `resume` or `suspend` multiple times, or releasing the timer without `resume`.