### PR TITLE
iOS-393 Implement protocol for download timeout and duration monitoring

### DIFF
--- a/NYPLAudiobookToolkit/Core/AudiobookTableOfContents.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookTableOfContents.swift
@@ -136,4 +136,11 @@ extension AudiobookTableOfContents: AudiobookNetworkServiceDelegate {
     public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
                                         didUpdateOverallDownloadProgress progress: Float) {
     }
+    
+    public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
+                                        didTimeoutFor spineElement: SpineElement?,
+                                        networkStatus: NetworkStatus) {
+        self.delegate?.audiobookTableOfContentsPendingStatusDidUpdate(inProgress: false)
+        self.delegate?.audiobookTableOfContentsDidRequestReload(self)
+    }
 }

--- a/NYPLAudiobookToolkit/Core/AudiobookTableOfContents.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookTableOfContents.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import NYPLUtilitiesObjc
 
 protocol AudiobookTableOfContentsDelegate: AnyObject {
     func audiobookTableOfContentsDidRequestReload(_ audiobookTableOfContents: AudiobookTableOfContents)
@@ -142,5 +143,11 @@ extension AudiobookTableOfContents: AudiobookNetworkServiceDelegate {
                                         networkStatus: NetworkStatus) {
         self.delegate?.audiobookTableOfContentsPendingStatusDidUpdate(inProgress: false)
         self.delegate?.audiobookTableOfContentsDidRequestReload(self)
+    }
+  
+    public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
+                                        downloadExceededTimeLimitFor spineElement: SpineElement,
+                                        elapsedTime: TimeInterval,
+                                        networkStatus: NetworkStatus) {
     }
 }

--- a/NYPLAudiobookToolkit/Network/AudiobookNetworkService.swift
+++ b/NYPLAudiobookToolkit/Network/AudiobookNetworkService.swift
@@ -235,6 +235,14 @@ extension DefaultAudiobookNetworkService: DownloadTaskDelegate {
             }
         }
     }
+  
+    public func downloadTaskExceededTimeLimit(_ downloadTask: DownloadTask, elapsedTime: Double) {
+        guard let spineElement = self.spineElementByKey[downloadTask.key] else {
+            return
+        }
+        self.notifyDelegatesOfDownloadExceededTimeLimitFor(spineElement,
+                                                           elapsedTime: elapsedTime)
+    }
 
     // Currently all these private methods are called on the main thread
 
@@ -266,6 +274,18 @@ extension DefaultAudiobookNetworkService: DownloadTaskDelegate {
         self.delegates.allObjects.forEach { delegate in
             delegate.audiobookNetworkService(self,
                                              didTimeoutFor: spineElement,
+                                             networkStatus: reachabilityManager?.currentReachabilityStatus() ?? NotReachable)
+        }
+    }
+  
+    /// No UI update is needed, can be called on background thread.
+    private func notifyDelegatesOfDownloadExceededTimeLimitFor(_ spineElement: SpineElement,
+                                                               elapsedTime: TimeInterval)
+    {
+        self.delegates.allObjects.forEach { delegate in
+            delegate.audiobookNetworkService(self,
+                                             downloadExceededTimeLimitFor: spineElement,
+                                             elapsedTime: elapsedTime,
                                              networkStatus: reachabilityManager?.currentReachabilityStatus() ?? NotReachable)
         }
     }

--- a/NYPLAudiobookToolkit/Network/DownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/DownloadTask.swift
@@ -51,3 +51,23 @@ import Foundation
     var key: String { get }
     weak var delegate: DownloadTaskDelegate? { get set }
 }
+
+public extension DownloadTask {
+    /// The timeout value is now based on user's connectivity, this is more like a fail-safe
+    /// if the timeout timer in the AudiobookNetworkService is not working properly.
+    static var timeoutValue: TimeInterval {
+        return 660.0
+    }
+  
+    static var monitoringTimerInterval: DispatchTimeInterval {
+        return .seconds(30)
+    }
+    
+    static var firstDownloadTimeLimit: TimeInterval {
+        return 30.0
+    }
+    
+    static var secondDownloadTimeLimit: TimeInterval {
+        return 180.0
+    }
+}

--- a/NYPLAudiobookToolkit/Network/DownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/DownloadTask.swift
@@ -14,6 +14,7 @@ import Foundation
     func downloadTaskDidDeleteAsset(_ downloadTask: DownloadTask)
     func downloadTaskDidUpdateDownloadPercentage(_ downloadTask: DownloadTask)
     func downloadTaskFailed(_ downloadTask: DownloadTask, withError error: NSError?)
+    func downloadTaskExceededTimeLimit(_ downloadTask: DownloadTask, elapsedTime: Double)
 }
 
 /// Protocol to handle hitting the network to download an audiobook.

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -724,6 +724,10 @@ extension AudiobookPlayerViewController: AudiobookNetworkServiceDelegate {
         self.presentAlertAndLog(error: nil)
         self.audiobookProgressView.stopShowingProgress()
     }
+    public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
+                                        downloadExceededTimeLimitFor spineElement: SpineElement,
+                                        elapsedTime: TimeInterval,
+                                        networkStatus: NetworkStatus) {}
 }
 
 extension AudiobookPlayerViewController: ScrubberViewDelegate {

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -3,6 +3,7 @@ import Foundation
 import PureLayout
 import AVKit
 import MediaPlayer
+import NYPLUtilitiesObjc
 
 let SkipTimeInterval: Double = 15
 
@@ -702,7 +703,7 @@ extension AudiobookPlayerViewController: AudiobookNetworkServiceDelegate {
     public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didUpdateProgressFor spineElement: SpineElement) {}
     public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didDeleteFileFor spineElement: SpineElement) {}
     public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didReceive error: NSError?, for spineElement: SpineElement) {
-        presentAlertAndLog(error: error)
+        self.presentAlertAndLog(error: error)
         self.audiobookProgressView.stopShowingProgress()
         if let error = error,
           error.domain == OverdrivePlayerErrorDomain && error.code == OverdrivePlayerError.downloadExpired.rawValue {
@@ -716,6 +717,12 @@ extension AudiobookPlayerViewController: AudiobookNetworkServiceDelegate {
             self.audiobookProgressView.stopShowingProgress()
         }
         self.audiobookProgressView.updateProgress(progress)
+    }
+    public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
+                                        didTimeoutFor spineElement: SpineElement?,
+                                        networkStatus: NetworkStatus) {
+        self.presentAlertAndLog(error: nil)
+        self.audiobookProgressView.stopShowingProgress()
     }
 }
 

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -721,8 +721,10 @@ extension AudiobookPlayerViewController: AudiobookNetworkServiceDelegate {
     public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
                                         didTimeoutFor spineElement: SpineElement?,
                                         networkStatus: NetworkStatus) {
-        self.presentAlertAndLog(error: nil)
-        self.audiobookProgressView.stopShowingProgress()
+        DispatchQueue.main.async {
+            self.presentAlertAndLog(error: nil)
+            self.audiobookProgressView.stopShowingProgress()
+        }
     }
     public func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
                                         downloadExceededTimeLimitFor spineElement: SpineElement,

--- a/NYPLAudiobookToolkitTests/AudiobookNetworkServiceTest.swift
+++ b/NYPLAudiobookToolkitTests/AudiobookNetworkServiceTest.swift
@@ -18,6 +18,7 @@ class RetryAfterErrorAudiobookNetworkServiceDelegate: AudiobookNetworkServiceDel
     func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didReceive error: NSError?, for spineElement: SpineElement) {
         audiobookNetworkService.fetch()
     }
+    func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didTimeoutFor spineElement: SpineElement?) { }
 }
 
 class AudiobookNetworkServiceTest: XCTestCase {


### PR DESCRIPTION
**What's this do?**
Implement timer and protocol for
- Download timeout for entire audiobooks
- Download duration monitoring for single download task

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-393](https://jira.nypl.org/browse/IOS-393)

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 