### PR TITLE
iOS-393 Update unit tests and mocks with new delegate functions

### DIFF
--- a/NYPLAudiobookToolkitTests/AudiobookNetworkServiceTest.swift
+++ b/NYPLAudiobookToolkitTests/AudiobookNetworkServiceTest.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import NYPLUtilitiesObjc
 @testable import NYPLAudiobookToolkit
 
 class RetryAfterErrorAudiobookNetworkServiceDelegate: AudiobookNetworkServiceDelegate {
@@ -18,7 +19,14 @@ class RetryAfterErrorAudiobookNetworkServiceDelegate: AudiobookNetworkServiceDel
     func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didReceive error: NSError?, for spineElement: SpineElement) {
         audiobookNetworkService.fetch()
     }
-    func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService, didTimeoutFor spineElement: SpineElement?) { }
+    func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
+                                 didTimeoutFor spineElement: SpineElement?,
+                                 networkStatus: NetworkStatus) { }
+    
+    func audiobookNetworkService(_ audiobookNetworkService: AudiobookNetworkService,
+                                 downloadExceededTimeLimitFor spineElement: SpineElement,
+                                 elapsedTime: TimeInterval,
+                                 networkStatus: NetworkStatus) { }
 }
 
 class AudiobookNetworkServiceTest: XCTestCase {

--- a/NYPLAudiobookToolkitTests/DownloadTaskMock.swift
+++ b/NYPLAudiobookToolkitTests/DownloadTaskMock.swift
@@ -23,6 +23,8 @@ class DownloadTaskMock: DownloadTask {
     }
     
     func delete() { }
+  
+    func cancel() { }
     
     let downloadProgress: Float
     

--- a/NYPLAudiobookToolkitTests/FeedbookAudiobookTest.swift
+++ b/NYPLAudiobookToolkitTests/FeedbookAudiobookTest.swift
@@ -34,6 +34,9 @@ class FeedbookAudiobookTest: XCTestCase {
       finished = true
       failed = true
     }
+    
+    func downloadTaskExceededTimeLimit(_ downloadTask: DownloadTask, elapsedTime: Double) {
+    }
   }
 
   func testFeedBookTimeExpired() {


### PR DESCRIPTION
**What's this do?**
Update the unit tests and mock with the newly added delegate functions

**Why are we doing this? (w/ JIRA link if applicable)**
I implemented new delegate functions without updating the unit tests and mocks in [last PR](https://github.com/NYPL-Simplified/NYPLAudiobookToolkit/pull/168)

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 