### PR TITLE
iOS-393 Add download completed property for audiobook background download

### DIFF
--- a/NYPLAudiobookToolkit/Network/AudiobookNetworkService.swift
+++ b/NYPLAudiobookToolkit/Network/AudiobookNetworkService.swift
@@ -36,6 +36,7 @@ import NYPLUtilitiesObjc
 @objc public protocol AudiobookNetworkService: AnyObject {
     var spine: [SpineElement] { get }
     var downloadProgress: Float { get }
+    var downloadCompleted: Bool { get }
     var isDownloading: Bool { get }
     
     /// Implementers of this should attempt to download all
@@ -77,6 +78,17 @@ public final class DefaultAudiobookNetworkService: AudiobookNetworkService {
         }
         ATLog(.debug, "ANS: Overall Download Progress: \(taskCompletedPercentage / Float(self.spine.count))")
         return taskCompletedPercentage / Float(self.spine.count)
+    }
+  
+    /// Since download progress would be 0 if the download has not begun,
+    /// we use this computed property to check if the files have been downloaded or not.
+    public var downloadCompleted: Bool {
+        for spineElement in self.spine {
+            if !spineElement.downloadTask.downloadCompleted {
+                return false
+            }
+        }
+        return true
     }
   
     public var isDownloading: Bool = false

--- a/NYPLAudiobookToolkit/Network/DownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/DownloadTask.swift
@@ -48,6 +48,7 @@ import Foundation
     func cancel()
     
     var downloadProgress: Float { get }
+    var downloadCompleted: Bool { get }
     var key: String { get }
     weak var delegate: DownloadTaskDelegate? { get set }
 }

--- a/NYPLAudiobookToolkit/Network/LCPDownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/LCPDownloadTask.swift
@@ -39,6 +39,9 @@ final class LCPDownloadTask: DownloadTask {
     
     /// All encrypted files are included in the audiobook, download progress is 1.0
     let downloadProgress: Float = 1.0
+  
+    /// All encrypted files are included in the audiobook, download completed
+    let downloadCompleted: Bool = true
     
     /// Spine element key
     let key: String

--- a/NYPLAudiobookToolkit/Network/OpenAccessDownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/OpenAccessDownloadTask.swift
@@ -38,6 +38,17 @@ final class OpenAccessDownloadTask: DownloadTask {
             self.delegate?.downloadTaskDidUpdateDownloadPercentage(self)
         }
     }
+  
+    /// Since download progress would be 0 if the download has not begun,
+    /// we use this computed property to check if the file has been downloaded or not.
+    var downloadCompleted: Bool {
+        switch assetFileStatus() {
+        case .saved(_):
+            return true
+        default:
+            return false
+        }
+    }
 
     let key: String
     let url: URL

--- a/NYPLAudiobookToolkit/Network/OverdriveDownloadTask.swift
+++ b/NYPLAudiobookToolkit/Network/OverdriveDownloadTask.swift
@@ -29,6 +29,17 @@ final class OverdriveDownloadTask: DownloadTask {
             self.delegate?.downloadTaskDidUpdateDownloadPercentage(self)
         }
     }
+  
+    /// Since download progress would be 0 if the download has not begun,
+    /// we use this computed property to check if the file has been downloaded or not.
+    var downloadCompleted: Bool {
+        switch assetFileStatus() {
+        case .saved(_):
+            return true
+        default:
+            return false
+        }
+    }
 
     let key: String
     let url: URL

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -82,7 +82,6 @@ let SkipTimeInterval: Double = 15
         self.activityIndicator.color = NYPLColor.disabledFieldTextColor
         self.audiobookManager.audiobook.player.registerDelegate(self)
         self.audiobookManager.networkService.registerDelegate(self)
-        self.audiobookManager.networkService.fetch()
 
         self.gradient.frame = self.view.bounds
         self.gradient.startPoint = CGPoint.zero

--- a/NYPLAudiobookToolkit/UI/AudiobookTrackTableViewCell.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookTrackTableViewCell.swift
@@ -15,28 +15,32 @@ class AudiobookTrackTableViewCell: UITableViewCell {
         let title = spineElement.chapter.title
         let detailLabel: String
         let labelAlpha: CGFloat
-        if progress == 0 {
-            let duration = HumanReadableTimestamp(timeInterval: spineDuration).timecode
-            self.detailTextLabel?.accessibilityLabel = HumanReadableTimestamp(timeInterval: spineDuration).accessibleDescription
-            let labelFormat = NSLocalizedString("%@", bundle: Bundle.audiobookToolkit()!, value: "%@", comment: "Timecode that means the length of the track")
-            detailLabel = String(format: labelFormat, duration)
-            labelAlpha = 0.4
-        } else if progress > 0 && progress < 1  {
+        if progress > 0 && progress < 1  {
+            // Spine element downloading in progress
             let percentage = HumanReadablePercentage(percentage: progress).value
             let labelFormat = NSLocalizedString("Downloading: %@%%", bundle: Bundle.audiobookToolkit()!, value: "Downloading: %@%%", comment: "The percentage of the chapter that has been downloaded, formatting for string should be localized at this point.")
             detailLabel = String(format: labelFormat, percentage)
             labelAlpha = 0.4
-        } else {
-            let duration = HumanReadableTimestamp(timeInterval: spineDuration).timecode
-            self.detailTextLabel?.accessibilityLabel = HumanReadableTimestamp(timeInterval: spineDuration).accessibleDescription
-            let labelFormat = NSLocalizedString("%@", bundle: Bundle.audiobookToolkit()!, value: "%@", comment: "Timecode that means the length of the track")
-            detailLabel = String(format: labelFormat, duration)
+        } else if (progress == 1 || spineElement.downloadTask.downloadCompleted) {
+            // Spine element download completed
+            detailLabel = customFormatString(for: spineDuration)
             labelAlpha = 1.0
+        } else {
+            // Spine element download not started
+            detailLabel = customFormatString(for: spineDuration)
+            labelAlpha = 0.4
         }
 
         self.textLabel?.text = title
         self.textLabel?.alpha = labelAlpha
         self.detailTextLabel?.text = detailLabel
         self.backgroundColor = NYPLColor.primaryBackgroundColor
+    }
+  
+    func customFormatString(for spineDuration: TimeInterval) -> String {
+        let duration = HumanReadableTimestamp(timeInterval: spineDuration).timecode
+        self.detailTextLabel?.accessibilityLabel = HumanReadableTimestamp(timeInterval: spineDuration).accessibleDescription
+        let labelFormat = NSLocalizedString("%@", bundle: Bundle.audiobookToolkit()!, value: "%@", comment: "Timecode that means the length of the track")
+        return String(format: labelFormat, duration)
     }
 }


### PR DESCRIPTION
**What's this do?**
We need a computed property to determine if an audiobook needs to be added to the download queue

**Why are we doing this? (w/ JIRA link if applicable)**
[Jira comment](https://jira.nypl.org/browse/IOS-393?focusedCommentId=70188&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-70188)

**How should this be tested? / Do these changes have associated tests?**
N/A

**Dependencies for merging? Releasing to production?**
N/A

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan 