### PR TITLE
IOS-437 Fix false positives in unit test runs

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -5,8 +5,8 @@ jobs:
   build-and-test:
     runs-on: macOS-latest
     steps:
-      - name: Force Xcode 13.1
-        run: sudo xcode-select -switch /Applications/Xcode_13.1.app
+      - name: Force latest Xcode #currently 13.2.1 cos 13.3.1 still in beta at github; once ready for prod the Xcode.app symlink will automatically select it
+        run: ls -la /Applications && sudo xcode-select -switch /Applications/Xcode.app
       - name: Print System Architecture
         run: uname -a
       - name: Checkout main repo and submodules

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -11,5 +11,5 @@ jobs:
         run: uname -a
       - name: Checkout main repo and submodules
         uses: actions/checkout@v2
-      - name: Run SPM Unit Tests
-        run: xcodebuild -scheme 'NYPLAudiobookToolkit' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad mini (6th generation)' test | if command -v xcpretty; then xcpretty; else cat; fi
+      - name: Run Unit Tests
+        run: scripts/run-unittests.sh

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/NYPL-Simplified/iOS-Utilities.git",
         "state": {
           "branch": "main",
-          "revision": "39ec99cdfc598da0984a3a51329df41a3e6a7612",
+          "revision": "ed011c9fa109ed306e9c9d30fd2552aa8bf832fe",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
       dependencies: ["NYPLUtilities", "PureLayout"],
       path: "NYPLAudiobookToolkit",
       exclude: [
-        "Info.plist", "NYPLAudiobookToolkit.h", "Core/Bundle.swift"
+        "Info.plist", "NYPLAudiobookToolkit.h", "Core/Bundle.swift", "scripts"
       ],
       resources: [
         .process("Resources")

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ NYPLAudiobookToolkit provides utilities and UI components for audiobook playback
 Requirements: 
 - Xcode 13
 
+# Unit Testing
+
+`./scripts/run-unittests.sh` 
+
+Unit testing on CI currently is done via xcodebuild because `swift test` is producing build errors.
+
 # Integration
 
 The only supported way to integrate NYPLAudioToolkit as a dependency is via SPM.

--- a/scripts/run-unittests.sh
+++ b/scripts/run-unittests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o pipefail
+set -e
+
+xcodebuild -scheme 'NYPLAudiobookToolkit' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPad mini (6th generation)' test | if command -v xcpretty; then xcpretty; else cat; fi


### PR DESCRIPTION
the previous inline script to execute the unit tests contained a unix pipe for xcpretty that swallowed the errors the upstream xcodebuild command was generating. By moving to a script file with `set -o pipefail` will ensure the pipe to also fail and report the error.