### PR TITLE
iOS-438 Migrate audiobook bookmark unit tests to NYPLAudiobookToolkit

### DIFF
--- a/NYPLAudiobookToolkit/Resources/Tests/invalid-locator-5.json
+++ b/NYPLAudiobookToolkit/Resources/Tests/invalid-locator-5.json
@@ -1,0 +1,9 @@
+{
+  "@type": "LocatorAudioBookTime",
+  "part": 3,
+  "chapter": -5,
+  "title": "Chapter title",
+  "audiobookID": "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+  "duration": 190000,
+  "time": 78000
+}

--- a/NYPLAudiobookToolkit/Resources/Tests/valid-locator-3.json
+++ b/NYPLAudiobookToolkit/Resources/Tests/valid-locator-3.json
@@ -1,0 +1,9 @@
+{
+  "@type": "LocatorAudioBookTime",
+  "part": 3,
+  "chapter": 32,
+  "title": "Chapter title",
+  "audiobookID": "urn:uuid:b309844e-7d4e-403e-945b-fbc78acd5e03",
+  "duration": 190000,
+  "time": 78000
+}

--- a/NYPLAudiobookToolkitTests/Bookmark/NYPLBookmarkSpec+AudiobookTests.swift
+++ b/NYPLAudiobookToolkitTests/Bookmark/NYPLBookmarkSpec+AudiobookTests.swift
@@ -1,0 +1,135 @@
+//
+//  NYPLBookmarkSpec+AudiobookTests.swift
+//
+//  Created by Ernest Fan on 2022-08-24.
+//  Copyright © 2022 NYPL. All rights reserved.
+//
+
+import XCTest
+import NYPLUtilities
+@testable import NYPLAudiobookToolkit
+
+class NYPLBookmarkSpec_AudiobookTests: XCTestCase {
+  var bundle: Bundle!
+
+  override func setUpWithError() throws {
+    bundle = Bundle(for: NYPLBookmarkSpec_AudiobookTests.self)
+  }
+
+  override func tearDownWithError() throws {
+    bundle = nil
+  }
+
+  func testMakeAudiobookLocatorFromJSON() throws {
+    // preconditions: get expected values from manually reading locator on disk
+    let locatorURL = Bundle.module.url(forResource: "valid-locator-3", withExtension: "json")!
+    let locatorData = try Data(contentsOf: locatorURL)
+    let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
+    let typeValue = json[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as! String
+    let title = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorTitleKey] as! String
+    let audiobookId = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorBookIDKey] as! String
+    let chapter = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorChapterKey] as! Int
+    let part = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorPartKey] as! Int
+    let duration = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorDurationKey] as! Double
+    let offset = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorOffsetKey] as! Double
+
+    // test: make a locator, encode it to binary, parse binary back to JSON
+    let madeLocatorString = NYPLAudiobookBookmarkFactory.makeLocatorString(title: title,
+                                                                           part: part,
+                                                                           chapter: chapter,
+                                                                           audiobookId: audiobookId,
+                                                                           duration: duration,
+                                                                           time: offset)
+    let madeLocatorData = madeLocatorString.data(using: .utf8)!
+    let madeJSONObject: Any
+    do {
+      try madeJSONObject = JSONSerialization.jsonObject(with: madeLocatorData)
+    } catch {
+      XCTFail("Unable to convert created locator to JSON: \(error)")
+      return
+    }
+    guard let madeJSON = madeJSONObject as? [String: Any] else {
+      XCTFail("Cannot cast JSON object to [String: Any]")
+      return
+    }
+    
+    // verify: parsing manually created locator should reveal same info of locator on disk
+    let parsedType = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
+    let parsedTitle = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorTitleKey] as? String
+    let parsedAudiobookId = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorBookIDKey] as? String
+    let parsedChapter = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorChapterKey] as? Int
+    let parsedPart = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorPartKey] as? Int
+    let parsedDuration = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorDurationKey] as? Double
+    let parsedOffset = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorOffsetKey] as? Double
+    XCTAssertNotNil(parsedType)
+    XCTAssertNotNil(parsedTitle)
+    XCTAssertNotNil(parsedAudiobookId)
+    XCTAssertFalse(parsedType!.isEmpty)
+    XCTAssertFalse(parsedTitle!.isEmpty)
+    XCTAssertFalse(parsedAudiobookId!.isEmpty)
+    
+    XCTAssertEqual(parsedType, typeValue)
+    XCTAssertEqual(parsedAudiobookId, audiobookId)
+    XCTAssertEqual(parsedChapter, chapter)
+    XCTAssertEqual(parsedPart, part)
+    XCTAssertEqual(parsedDuration, duration)
+    XCTAssertEqual(parsedOffset, offset)
+  }
+  
+  func testInvalidAudiobookLocatorNegativeChapterFromJSON() throws {
+    // preconditions: get expected values from manually reading locator on disk
+    let locatorURL = Bundle.module.url(forResource: "invalid-locator-5", withExtension: "json")!
+    let locatorData = try Data(contentsOf: locatorURL)
+    let json = try JSONSerialization.jsonObject(with: locatorData) as! [String: Any]
+    let typeValue = json[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as! String
+    let title = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorTitleKey] as! String
+    let audiobookId = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorBookIDKey] as! String
+    let chapter = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorChapterKey] as! Int
+    let part = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorPartKey] as! Int
+    let duration = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorDurationKey] as! Double
+    let offset = json[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorOffsetKey] as! Double
+    XCTAssertLessThan(chapter, 0)
+
+    // test: make a locator, encode it to binary, parse binary back to JSON
+    let madeLocatorString = NYPLAudiobookBookmarkFactory.makeLocatorString(title: title,
+                                                                           part: part,
+                                                                           chapter: chapter,
+                                                                           audiobookId: audiobookId,
+                                                                           duration: duration,
+                                                                           time: offset)
+    let madeLocatorData = madeLocatorString.data(using: .utf8)!
+    let madeJSONObject: Any
+    do {
+      try madeJSONObject = JSONSerialization.jsonObject(with: madeLocatorData)
+    } catch {
+      XCTFail("Unable to convert created locator to JSON: \(error)")
+      return
+    }
+    guard let madeJSON = madeJSONObject as? [String: Any] else {
+      XCTFail("Cannot cast JSON object to [String: Any]")
+      return
+    }
+
+    // verify: parsing manually created locator should reveal same info of locator on disk
+    let parsedType = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.locatorTypeKey] as? String
+    let parsedTitle = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorTitleKey] as? String
+    let parsedAudiobookId = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorBookIDKey] as? String
+    let parsedChapter = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorChapterKey] as? Int
+    let parsedPart = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorPartKey] as? Int
+    let parsedDuration = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorDurationKey] as? Double
+    let parsedOffset = madeJSON[NYPLBookmarkSpec.Target.Selector.Value.audiobookLocatorOffsetKey] as? Double
+    XCTAssertNotNil(parsedType)
+    XCTAssertNotNil(parsedTitle)
+    XCTAssertNotNil(parsedAudiobookId)
+    XCTAssertFalse(parsedType!.isEmpty)
+    XCTAssertFalse(parsedTitle!.isEmpty)
+    XCTAssertFalse(parsedAudiobookId!.isEmpty)
+    
+    XCTAssertEqual(parsedType, typeValue)
+    XCTAssertEqual(parsedAudiobookId, audiobookId)
+    XCTAssertEqual(parsedChapter, 0)
+    XCTAssertEqual(parsedPart, part)
+    XCTAssertEqual(parsedDuration, duration)
+    XCTAssertEqual(parsedOffset, offset)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -34,6 +34,9 @@ let package = Package(
       path: "NYPLAudiobookToolkitTests",
       exclude: [
         "Info.plist"
+      ],
+      resources: [
+        .copy("Resources/Tests/")
       ]
     ),
   ]


### PR DESCRIPTION
**What's this do?**
Migrate audiobook bookmark unit tests from Simplified-iOS to NYPLAudiobookToolkit

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-438](https://jira.nypl.org/browse/IOS-438)

**How should this be tested? / Do these changes have associated tests?**
Run associated unit tests