### PR TITLE
Update iOS-Util commit ref and add audiobook bookmark comparison code

### DIFF
--- a/NYPLAudiobookToolkit/Bookmarks/NYPLAudiobookBookmark.swift
+++ b/NYPLAudiobookToolkit/Bookmarks/NYPLAudiobookBookmark.swift
@@ -133,3 +133,70 @@ import NYPLUtilities
     return [:]
   }
 }
+
+public extension NYPLAudiobookBookmark {
+  /// Determines if a given chapter location matches the location addressed by this
+  /// bookmark.
+  ///
+  /// - Complexity: O(*1*).
+  ///
+  /// - Parameters:
+  ///   - locator: The object representing the given location in the audiobook
+  ///
+  /// - Returns: `true` if the chapter location's position matches the bookmark's.
+  func locationMatches(_ location: ChapterLocation) -> Bool {
+    guard self.audiobookId == location.audiobookID,
+          self.chapter == location.number,
+          self.part == location.part,
+          self.duration == location.duration else {
+      return false
+    }
+    
+    return Float(self.time) =~= Float(location.playheadOffset)
+  }
+  
+  override func isEqual(_ object: Any?) -> Bool {
+    guard let other = object as? NYPLAudiobookBookmark else {
+      return false
+    }
+
+    guard self.audiobookId == other.audiobookId,
+          self.chapter == other.chapter,
+          self.part == other.part,
+          self.duration == other.duration else {
+      return false
+    }
+    
+    return Float(self.time) =~= Float(other.time)
+  }
+}
+
+extension NYPLAudiobookBookmark: Comparable {
+  public static func < (lhs: NYPLAudiobookBookmark, rhs: NYPLAudiobookBookmark) -> Bool {
+    if lhs.part != rhs.part {
+      return lhs.part < rhs.part
+    } else if lhs.chapter != rhs.chapter {
+      return lhs.chapter < rhs.chapter
+    } else {
+      return lhs.time < rhs.time
+    }
+  }
+  
+  public static func == (lhs: NYPLAudiobookBookmark, rhs: NYPLAudiobookBookmark) -> Bool {
+    guard lhs.audiobookId == rhs.audiobookId,
+          lhs.chapter == rhs.chapter,
+          lhs.part == rhs.part,
+          lhs.duration == rhs.duration else {
+      return false
+    }
+    
+    return Float(lhs.time) =~= Float(rhs.time)
+  }
+}
+
+@objc
+public extension NYPLAudiobookBookmark {
+  @objc func lessThan(_ bookmark: NYPLAudiobookBookmark) -> Bool {
+    return self < bookmark
+  }
+}

--- a/NYPLAudiobookToolkit/Bookmarks/NYPLAudiobookBookmarkFactory.swift
+++ b/NYPLAudiobookToolkit/Bookmarks/NYPLAudiobookBookmarkFactory.swift
@@ -1,12 +1,6 @@
 import Foundation
 import NYPLUtilities
 
-public protocol NYPLBookmarkSelectorParsing {
-  static func parseSelectorJSONString(fromServerAnnotation annotation: [String: Any],
-                                     annotationType: NYPLBookmarkSpec.Motivation,
-                                     bookID: String) -> String?
-}
-
 // TODO: iOS-444 Implement NYPLAudiobookBookmarkFactory and related unit tests
 public final class NYPLAudiobookBookmarkFactory {
   /// Factory method to create a new bookmark from a server annotation.

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/NYPL-Simplified/iOS-Utilities.git",
         "state": {
           "branch": "main",
-          "revision": "3ca978a0ef49470fd78e1fb889eeed7ae2c6d3d3",
+          "revision": "b26a3340c5dd38efc5de1d6b15f4cf62e94a6f5a",
           "version": null
         }
       },


### PR DESCRIPTION
**What's this do?**
Move audiobook bookmark comparison code from Simplified-repo
Update iOS-Utilities commit ref
Remove NYPLBookmarkSelectorParsing protocol since it's now moved to iOS-Util repo

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-423](https://jira.nypl.org/browse/IOS-423)

**How should this be tested? / Do these changes have associated tests?**
Will implement unit tests

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan
