### PR TITLE
iOS-420 Last listened position sync

### DIFF
--- a/NYPLAudiobookToolkit/Bookmarks/NYPLLastListenPositionSynchronizing.swift
+++ b/NYPLAudiobookToolkit/Bookmarks/NYPLLastListenPositionSynchronizing.swift
@@ -1,0 +1,15 @@
+//
+//  NYPLLastListenPositionSynchronizing.swift
+//  
+//
+//  Created by Ernest Fan on 2022-11-29.
+//
+
+import Foundation
+
+@objc
+public protocol NYPLLastListenPositionSynchronizing {
+  func getLastListenPosition(completion: @escaping (_ localPosition: NYPLAudiobookBookmark?, _ serverPosition: NYPLAudiobookBookmark?) -> ())
+  func updateLastListenPositionInMemory(_ location: ChapterLocation)
+  func syncLastListenPositionToServer()
+}

--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -160,8 +160,10 @@ var sharedLogHandler: LogHandler?
         self.timerDelegate?.audiobookManager(self, didUpdate: timer)
         guard self.audiobook.player.isLoaded else { return }
         if let chapter = self.audiobook.player.currentChapterLocation {
-            self.lastListenPositionSynchronizer?.updateLastListenPositionInMemory(chapter)
-          
+            if self.audiobook.player.isPlaying {
+                self.lastListenPositionSynchronizer?.updateLastListenPositionInMemory(chapter)
+            }
+            
             var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
             if let title = chapter.title {
                 info[MPMediaItemPropertyTitle] = title
@@ -197,7 +199,7 @@ var sharedLogHandler: LogHandler?
         return
       }
       
-      self.audiobook.player.movePlayheadToLocation(location)
+      self.audiobook.player.movePlayhead(to: location, shouldBeginAutoPlay: false)
     }
 }
 
@@ -223,7 +225,7 @@ extension DefaultAudiobookManager: PlayerDelegate {
         }
         if lastChapter.inSameChapter(other: chapter) {
             self.playbackCompletionHandler?()
-            self.audiobook.player.movePlayheadToLocation(firstChapter)
+            self.audiobook.player.movePlayhead(to: firstChapter, shouldBeginAutoPlay: false)
         }
     }
     public func playerDidUnload(_ player: Player) {

--- a/NYPLAudiobookToolkit/Core/AudiobookManager.swift
+++ b/NYPLAudiobookToolkit/Core/AudiobookManager.swift
@@ -230,6 +230,7 @@ extension DefaultAudiobookManager: PlayerDelegate {
     }
     public func playerDidUnload(_ player: Player) {
       self.mediaControlHandler.teardown()
+      lastListenPositionSynchronizer?.syncLastListenPositionToServer()
       self.timer?.invalidate()
     }
 }

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -160,7 +160,7 @@ class OpenAccessPlayer: NSObject, Player {
     ///
     /// - Parameter newLocation: Chapter Location with possible playhead offset
     ///   outside the bounds of audio for the current chapter
-    /// - Parameter shouldBeginAutoPlay: Pass in `true` will allow the player
+    /// - Parameter shouldBeginAutoPlay: Passing in `true` will allow the player
     ///   to begin playing if player is originally in `pause` state and ready to play
     func movePlayhead(to location: ChapterLocation, shouldBeginAutoPlay: Bool)
     {

--- a/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
+++ b/NYPLAudiobookToolkit/Player/OpenAccessPlayer.swift
@@ -145,7 +145,7 @@ class OpenAccessPlayer: NSObject, Player {
                                                     requestedSkipDuration: timeInterval)
 
         if let destinationLocation = currentLocation.update(playheadOffset: adjustedOffset) {
-            self.playAtLocation(destinationLocation)
+            movePlayhead(to: destinationLocation, shouldBeginAutoPlay: true)
             let newPlayhead = move(cursor: self.cursor, to: destinationLocation)
             completion?(newPlayhead.location)
         } else {
@@ -160,9 +160,11 @@ class OpenAccessPlayer: NSObject, Player {
     ///
     /// - Parameter newLocation: Chapter Location with possible playhead offset
     ///   outside the bounds of audio for the current chapter
-    func playAtLocation(_ newLocation: ChapterLocation)
+    /// - Parameter shouldBeginAutoPlay: Pass in `true` will allow the player
+    ///   to begin playing if player is originally in `pause` state and ready to play
+    func movePlayhead(to location: ChapterLocation, shouldBeginAutoPlay: Bool)
     {
-        let newPlayhead = move(cursor: self.cursor, to: newLocation)
+        let newPlayhead = move(cursor: self.cursor, to: location)
 
         guard let newItemDownloadStatus = assetFileStatus(newPlayhead.cursor.currentElement.downloadTask) else {
             let error = NSError(domain: errorDomain, code: OpenAccessPlayerError.unknown.rawValue, userInfo: nil)
@@ -183,29 +185,25 @@ class OpenAccessPlayer: NSObject, Player {
                 if success {
                     self.cursor = newPlayhead.cursor
                     self.seekWithinCurrentItem(newOffset: newPlayhead.location.playheadOffset)
-                    self.play()
+                    if shouldBeginAutoPlay {
+                        self.play()
+                    }
                 } else {
                     ATLog(.error, "Failed to create a new queue for the player. Keeping playback at the current player item.")
                     let error = NSError(domain: errorDomain, code: OpenAccessPlayerError.unknown.rawValue, userInfo: nil)
-                    self.notifyDelegatesOfPlaybackFailureFor(chapter: newLocation, error)
+                    self.notifyDelegatesOfPlaybackFailureFor(chapter: location, error)
                 }
             }
         case .missing(_):
             // TODO: Could eventually handle streaming from here.
             let error = NSError(domain: errorDomain, code: OpenAccessPlayerError.downloadNotFinished.rawValue, userInfo: nil)
-            self.notifyDelegatesOfPlaybackFailureFor(chapter: newLocation, error)
+            notifyDelegatesOfPlaybackFailureFor(chapter: location, error)
             return
         case .unknown:
             let error = NSError(domain: errorDomain, code: OpenAccessPlayerError.unknown.rawValue, userInfo: nil)
-            self.notifyDelegatesOfPlaybackFailureFor(chapter: newLocation, error)
+            notifyDelegatesOfPlaybackFailureFor(chapter: location, error)
             return
         }
-    }
-
-    func movePlayheadToLocation(_ location: ChapterLocation)
-    {
-        self.playAtLocation(location)
-        self.pause()
     }
 
     /// Moving within the current AVPlayerItem.

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -69,16 +69,14 @@ import Foundation
     /// returns the actual time interval delivered to the Player.
     func skipPlayhead(_ timeInterval: TimeInterval, completion: ((ChapterLocation)->())?) -> ()
 
-    /// Move playhead and immediately start playing
-    /// This method is useful for scenarios like a table of contents
-    /// where you select a new chapter and wish to immediately start
-    /// playback.
-    func playAtLocation(_ location: ChapterLocation)
-    
-    /// Move playhead but do not start playback. This is useful for
-    /// state restoration where we want to prepare for playback
-    /// at a specific point, but playback has not yet been requested.
-    func movePlayheadToLocation(_ location: ChapterLocation)
+    /// Move playhead to specific chapter location
+    /// This method is useful for scenarios like
+    /// 1. navigating to a chapter from table of contents
+    /// 2. navigating to a bookmark location
+    /// 3. restoring last listened position
+    /// Pass `true` to `shouldBeginAutoPlay` to begin playback immediately
+    /// if the player is paused and ready to play.
+    func movePlayhead(to location: ChapterLocation, shouldBeginAutoPlay: Bool)
 
     func registerDelegate(_ delegate: PlayerDelegate)
     func removeDelegate(_ delegate: PlayerDelegate)

--- a/NYPLAudiobookToolkit/Player/Player.swift
+++ b/NYPLAudiobookToolkit/Player/Player.swift
@@ -135,6 +135,16 @@ import Foundation
         self.title = title
         
     }
+  
+    public convenience init?(from bookmark: NYPLAudiobookBookmark) {
+      self.init(number: bookmark.chapter,
+                part: bookmark.part,
+                duration: bookmark.duration,
+                startOffset: 0,
+                playheadOffset: bookmark.time,
+                title: bookmark.title,
+                audiobookID: bookmark.audiobookId)
+    }
 
     public func update(playheadOffset offset: TimeInterval) -> ChapterLocation? {
         return ChapterLocation(

--- a/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
+++ b/NYPLAudiobookToolkit/UI/AudiobookPlayerViewController.swift
@@ -734,7 +734,7 @@ extension AudiobookPlayerViewController: AudiobookReaderPositionSelectionDelegat
   }
   
   func advancePlayer(to chapter: ChapterLocation) {
-    audiobookManager.audiobook.player.playAtLocation(chapter)
+    audiobookManager.audiobook.player.movePlayhead(to: chapter, shouldBeginAutoPlay: true)
     waitingForPlayer = true
     activityIndicator.startAnimating()
 

--- a/NYPLAudiobookToolkitTests/PlayerMock.swift
+++ b/NYPLAudiobookToolkitTests/PlayerMock.swift
@@ -14,9 +14,7 @@ class PlayerMock: Player {
 
     var isLoaded: Bool = false
 
-    func playAtLocation(_ location: ChapterLocation) { }
-    
-    func movePlayheadToLocation(_ location: ChapterLocation) { }
+    func movePlayhead(to location: ChapterLocation, shouldBeginAutoPlay: Bool) { }
     
     var playbackRate: PlaybackRate = .normalTime
     


### PR DESCRIPTION
**What's this do?**
Implement protocol for syncing last listen position
Refactor `movePlayhead` and `playAtLocation` in `Player` class

**Why are we doing this? (w/ JIRA link if applicable)**
[iOS-420](https://jira.nypl.org/browse/IOS-420)

**How should this be tested? / Do these changes have associated tests?**
Need to be tested in SimplyE

**Dependencies for merging? Releasing to production?**
No

**Does this include changes that require a new SimplyE/Open eBooks build for QA?**
N/A, not testable by QA yet

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@ErnestFan
